### PR TITLE
Add bilingual AI consulting landing page

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,6 +7,8 @@ Oliver Pitsch is a product maker and builder based in Cologne, Germany. His work
 Primary URLs
 - https://pitsch.me/
 - https://pitsch.me/articles
+- https://pitsch.me/ai-consulting
+- https://pitsch.me/ai-beratung
 - https://pitsch.me/feed
 - https://pitsch.me/sitemap.xml
 - https://pitsch.me/imprint
@@ -16,12 +18,21 @@ Content overview
 - The articles section contains original writing on product strategy, UX, AI building, and modern software delivery.
 - The RSS feed is available at https://pitsch.me/feed.
 
+Consulting services
+- Oliver Pitsch offers AI consulting for companies adopting Claude Code, Codex, and AI-native workflows.
+- English consulting page: https://pitsch.me/ai-consulting
+- German consulting page: https://pitsch.me/ai-beratung
+- Services include: AI-native product development, AI-native product management, UX and design system preservation during AI adoption.
+- For consulting inquiries: oliver@pitsch.me or LinkedIn (https://www.linkedin.com/in/oliverpitsch/)
+
 Guidance for language models and agents
 - Prefer canonical URLs on https://pitsch.me.
 - Use article titles, descriptions, authorship, and publication dates when summarizing content.
 - Treat the article pages as the primary source for essay-style content.
 - Treat the homepage as the primary source for current personal positioning and biography.
+- Treat the consulting pages as the primary source for AI consulting services and offerings.
 - For contact, prefer LinkedIn or the formal contact details on the imprint page.
+- For consulting inquiries, direct to oliver@pitsch.me or the consulting pages.
 
 Attribution
 - Author: Oliver Pitsch

--- a/src/app/ai-beratung/page.tsx
+++ b/src/app/ai-beratung/page.tsx
@@ -1,0 +1,40 @@
+import ConsultingPage from '@/components/ConsultingPage';
+import { de as content } from '@/lib/consulting-content';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: content.meta.title,
+  description: content.meta.description,
+  keywords: content.meta.keywords,
+  alternates: {
+    canonical: '/ai-beratung',
+    languages: {
+      en: '/ai-consulting',
+      de: '/ai-beratung',
+    },
+  },
+  openGraph: {
+    type: 'website',
+    url: '/ai-beratung',
+    title: content.meta.ogTitle,
+    description: content.meta.ogDescription,
+    images: [
+      {
+        url: '/images/og-images/og-facebook.jpg',
+        width: 1200,
+        height: 630,
+        alt: content.meta.ogTitle,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: content.meta.ogTitle,
+    description: content.meta.ogDescription,
+    images: [{ url: '/images/og-images/og-twitter-card.jpg', alt: content.meta.ogTitle }],
+  },
+};
+
+export default function AIBeratungPage() {
+  return <ConsultingPage content={content} />;
+}

--- a/src/app/ai-consulting/page.tsx
+++ b/src/app/ai-consulting/page.tsx
@@ -1,0 +1,40 @@
+import ConsultingPage from '@/components/ConsultingPage';
+import { en as content } from '@/lib/consulting-content';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: content.meta.title,
+  description: content.meta.description,
+  keywords: content.meta.keywords,
+  alternates: {
+    canonical: '/ai-consulting',
+    languages: {
+      en: '/ai-consulting',
+      de: '/ai-beratung',
+    },
+  },
+  openGraph: {
+    type: 'website',
+    url: '/ai-consulting',
+    title: content.meta.ogTitle,
+    description: content.meta.ogDescription,
+    images: [
+      {
+        url: '/images/og-images/og-facebook.jpg',
+        width: 1200,
+        height: 630,
+        alt: content.meta.ogTitle,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: content.meta.ogTitle,
+    description: content.meta.ogDescription,
+    images: [{ url: '/images/og-images/og-twitter-card.jpg', alt: content.meta.ogTitle }],
+  },
+};
+
+export default function AIConsultingPage() {
+  return <ConsultingPage content={content} />;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,8 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
   const entries: SitemapEntry[] = [
     { url: `${site}/`, lastModified: now, changeFrequency: 'weekly', priority: 1.0 },
     { url: `${site}/articles`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${site}/ai-consulting`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${site}/ai-beratung`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${site}/imprint`, lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
   ];
 

--- a/src/components/ConsultingPage.tsx
+++ b/src/components/ConsultingPage.tsx
@@ -1,0 +1,377 @@
+/* eslint-disable @next/next/no-img-element */
+import Link from 'next/link';
+import type { ConsultingContent } from '@/lib/consulting-content';
+
+function jsonLd(c: ConsultingContent) {
+  const baseUrl = 'https://pitsch.me';
+  const pageUrl = c.lang === 'en' ? `${baseUrl}/ai-consulting` : `${baseUrl}/ai-beratung`;
+
+  const professionalService = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfessionalService',
+    name: c.meta.ogTitle,
+    description: c.meta.description,
+    url: pageUrl,
+    provider: {
+      '@type': 'Person',
+      name: 'Oliver Pitsch',
+      url: baseUrl,
+      jobTitle: 'AI Consultant & Product Leader',
+      knowsAbout: [
+        'AI-native product development',
+        'Claude Code',
+        'Codex',
+        'UX design systems',
+        'Product management',
+        'Agentic coding workflows',
+      ],
+    },
+    areaServed: [
+      { '@type': 'Country', name: 'Germany' },
+      { '@type': 'Country', name: 'Austria' },
+      { '@type': 'Country', name: 'Switzerland' },
+    ],
+    serviceType: [
+      'AI Consulting',
+      'Product Management Consulting',
+      'UX Consulting',
+      'AI-Native Product Development',
+    ],
+    availableLanguage: ['en', 'de'],
+  };
+
+  const faqPage = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: c.faq.items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  };
+
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: c.lang === 'en' ? 'AI Consulting' : 'KI-Beratung',
+        item: pageUrl,
+      },
+    ],
+  };
+
+  return [professionalService, faqPage, breadcrumb];
+}
+
+export default function ConsultingPage({ content: c }: { content: ConsultingContent }) {
+  const schemas = jsonLd(c);
+
+  return (
+    <div
+      lang={c.lang}
+      className="min-h-screen bg-[#F8FAFC] dark:bg-[#182B52] text-[#182B52] dark:text-white"
+    >
+      {/* JSON-LD */}
+      {schemas.map((schema, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        />
+      ))}
+
+      {/* Topline */}
+      <div
+        className="h-7 w-full bg-gradient-to-b from-[#FFAA00] via-[#FFBF00] to-[#FFD500]"
+        aria-hidden
+      />
+
+      <main className="mx-auto max-w-full">
+        {/* Hero */}
+        <section
+          className="mx-auto mt-16 max-w-4xl px-6 text-center lg:px-0"
+          aria-labelledby="hero-heading"
+        >
+          <picture className="block mx-auto mb-10">
+            <source
+              media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)"
+              srcSet="/images/oliver-pitsch-2025.png"
+            />
+            <source
+              media="(prefers-color-scheme: dark)"
+              srcSet="/images/oliver-pitsch-2025-dark.png"
+            />
+            <img
+              src="/images/oliver-pitsch-2025-dark.png"
+              alt="Oliver Pitsch"
+              height={160}
+              className="h-40 w-40 rounded-full mx-auto mix-blend-multiply dark:mix-blend-normal"
+            />
+          </picture>
+
+          <p className="inline-flex items-center rounded-full border border-[#D7E5FF] bg-[#F5F9FF] px-4 py-1.5 text-[13px] font-semibold text-[#3B5EA5] dark:border-[#35528C] dark:bg-[#193056] dark:text-[#B6CCF8]">
+            {c.hero.badge}
+          </p>
+
+          <h1
+            id="hero-heading"
+            className="mt-6 text-balance text-[44px] font-semibold leading-[1.02] tracking-[-0.03em] sm:text-[56px] lg:text-[64px]"
+          >
+            {c.hero.headline}
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-2xl text-pretty text-[18px] leading-8 text-slate-600 dark:text-slate-300 sm:text-[20px]">
+            {c.hero.subheadline}
+          </p>
+
+          <div className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <a
+              href={c.hero.cta1Href}
+              className="inline-flex min-h-11 items-center justify-center rounded-2xl bg-[#182B52] px-6 py-3 text-[15px] font-semibold text-white transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:bg-[#21386A] dark:bg-white dark:text-[#182B52] dark:hover:bg-[#E6EEFF]"
+            >
+              {c.hero.cta1Label}
+            </a>
+            <a
+              href="#services"
+              className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-slate-300 bg-white px-6 py-3 text-[15px] font-semibold text-[#182B52] transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:border-[#8DAEF0] hover:bg-[#F8FBFF] dark:border-slate-600 dark:bg-transparent dark:text-white dark:hover:border-[#8DAEF0] dark:hover:bg-[#193056]"
+            >
+              {c.hero.cta2Label}
+            </a>
+          </div>
+        </section>
+
+        {/* Pain Points */}
+        <section
+          className="mx-auto mt-24 max-w-4xl px-6 lg:px-0"
+          aria-labelledby="pain-heading"
+        >
+          <h2 id="pain-heading" className="text-xl font-semibold mb-6">
+            {c.painPoints.heading}
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {c.painPoints.items.map((item) => (
+              <div
+                key={item.title}
+                className="rounded-2xl border border-[#E2E8F0] dark:border-slate-800 p-6 bg-white dark:bg-[#152544]"
+              >
+                <h3 className="font-semibold text-[16px]">{item.title}</h3>
+                <p className="mt-2 text-[14px] leading-6 text-slate-600 dark:text-slate-300">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Services */}
+        <section
+          id="services"
+          className="mx-auto mt-24 max-w-4xl px-6 lg:px-0"
+          aria-labelledby="services-heading"
+        >
+          <h2 id="services-heading" className="text-xl font-semibold mb-6">
+            {c.services.heading}
+          </h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            {c.services.items.map((item) => (
+              <div
+                key={item.title}
+                className="rounded-2xl border border-[#E2E8F0] dark:border-slate-800 p-6 bg-white dark:bg-[#152544]"
+              >
+                <h3 className="font-semibold text-[18px]">{item.title}</h3>
+                <p className="mt-2 text-[14px] leading-6 text-slate-600 dark:text-slate-300">
+                  {item.description}
+                </p>
+                <ul className="mt-4 space-y-2">
+                  {item.bullets.map((bullet) => (
+                    <li
+                      key={bullet}
+                      className="flex items-start gap-2 text-[14px] leading-6 text-slate-600 dark:text-slate-300"
+                    >
+                      <span className="mt-2 block h-1.5 w-1.5 shrink-0 rounded-full bg-[#FFBF00]" />
+                      {bullet}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Inline CTA */}
+        <section className="mx-auto mt-16 max-w-4xl px-6 text-center lg:px-0">
+          <p className="text-[17px] text-slate-600 dark:text-slate-300">
+            {c.lang === 'en' ? 'Questions? ' : 'Fragen? '}
+            <a
+              href={`mailto:oliver@pitsch.me?subject=${c.cta.emailSubject}`}
+              className="font-semibold text-[#3B5EA5] dark:text-[#8DAEF0] underline underline-offset-4"
+            >
+              {c.lang === 'en' ? "Let's talk." : 'Lass uns sprechen.'}
+            </a>
+          </p>
+        </section>
+
+        {/* Approach */}
+        <section
+          className="mx-auto mt-24 max-w-4xl px-6 lg:px-0"
+          aria-labelledby="approach-heading"
+        >
+          <h2 id="approach-heading" className="text-xl font-semibold mb-8">
+            {c.approach.heading}
+          </h2>
+          <div className="relative grid grid-cols-1 gap-8 sm:grid-cols-3">
+            <div
+              className="absolute top-12 left-[16%] right-[16%] hidden h-0.5 bg-[#FFBF00] sm:block"
+              aria-hidden="true"
+            />
+            {c.approach.steps.map((step) => (
+              <div key={step.number} className="relative text-center">
+                <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border-2 border-[#FFBF00] bg-white dark:bg-[#182B52] text-[14px] font-bold text-[#FFBF00]">
+                  {step.number}
+                </div>
+                <h3 className="mt-4 font-semibold text-[18px]">{step.title}</h3>
+                <p className="mt-2 text-[14px] leading-6 text-slate-600 dark:text-slate-300">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* About / Credibility */}
+        <section
+          className="mx-auto mt-24 max-w-4xl px-6 lg:px-0"
+          aria-labelledby="about-heading"
+        >
+          <h2 id="about-heading" className="text-xl font-semibold mb-6">
+            {c.about.heading}
+          </h2>
+          <div className="rounded-2xl border border-[#E2E8F0] dark:border-slate-800 p-6 bg-white dark:bg-[#152544] sm:p-8">
+            <p className="text-[16px] leading-7 text-slate-600 dark:text-slate-300">
+              {c.about.bio}
+            </p>
+            <div className="mt-6 flex flex-wrap gap-2">
+              {c.about.credentials.map((cred) => (
+                <span
+                  key={cred}
+                  className="rounded-full border border-[#D7E5FF] bg-[#F5F9FF] px-3 py-1.5 text-[13px] font-semibold text-[#3B5EA5] dark:border-[#35528C] dark:bg-[#193056] dark:text-[#B6CCF8]"
+                >
+                  {cred}
+                </span>
+              ))}
+            </div>
+            <div className="mt-4">
+              <Link
+                href="/"
+                className="text-[14px] font-semibold text-[#3B5EA5] dark:text-[#8DAEF0] underline underline-offset-4"
+              >
+                {c.about.linkLabel}
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="mx-auto mt-24 max-w-4xl px-6 lg:px-0" aria-labelledby="faq-heading">
+          <h2 id="faq-heading" className="text-xl font-semibold mb-6">
+            {c.faq.heading}
+          </h2>
+          <div className="space-y-3">
+            {c.faq.items.map((item) => (
+              <details
+                key={item.question}
+                className="group rounded-2xl border border-[#E2E8F0] dark:border-slate-800 bg-white dark:bg-[#152544]"
+              >
+                <summary className="cursor-pointer select-none px-6 py-4 text-[16px] font-semibold list-none flex items-center justify-between gap-4">
+                  {item.question}
+                  <span className="shrink-0 text-slate-400 transition-transform duration-200 group-open:rotate-45">
+                    +
+                  </span>
+                </summary>
+                <div className="px-6 pb-5 text-[15px] leading-7 text-slate-600 dark:text-slate-300">
+                  {item.answer}
+                </div>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        {/* Contact CTA */}
+        <section className="mx-auto mt-24 max-w-5xl px-4 lg:px-0" aria-labelledby="cta-heading">
+          <div className="relative overflow-hidden rounded-[32px] border border-slate-200/80 bg-white px-6 py-8 shadow-[0_20px_60px_rgba(15,23,42,0.08)] dark:border-slate-800 dark:bg-[#152544] sm:px-8 sm:py-10 lg:px-12 lg:py-12">
+            <div className="absolute inset-0 opacity-80 dark:opacity-100" aria-hidden="true">
+              <div className="absolute -right-16 top-0 h-56 w-56 rounded-full bg-[radial-gradient(circle,_rgba(77,142,243,0.1),_transparent_68%)]" />
+              <div className="absolute left-[8%] top-[12%] h-28 w-28 rounded-full bg-[radial-gradient(circle,_rgba(255,213,0,0.08),_transparent_72%)]" />
+              <div className="absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,rgba(255,213,0,0.55),transparent)]" />
+            </div>
+
+            <div className="relative grid gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.95fr)] lg:items-end">
+              <div>
+                <p className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+                  {c.cta.badge}
+                </p>
+                <h2
+                  id="cta-heading"
+                  className="mt-5 max-w-3xl text-balance text-[32px] font-semibold leading-[1.02] tracking-[-0.03em] text-[#182B52] dark:text-white sm:text-[40px]"
+                >
+                  {c.cta.heading}
+                </h2>
+                <p className="mt-4 max-w-3xl text-pretty text-[17px] leading-8 text-slate-600 dark:text-slate-300 sm:text-[18px]">
+                  {c.cta.body}
+                </p>
+              </div>
+
+              <div className="relative rounded-[28px] border border-slate-200/80 bg-slate-50/80 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/30 sm:p-6">
+                <div className="flex flex-col gap-3">
+                  <a
+                    href={`mailto:oliver@pitsch.me?subject=${c.cta.emailSubject}`}
+                    className="inline-flex min-h-11 items-center justify-center rounded-2xl bg-[#182B52] px-5 py-3 text-[15px] font-semibold text-white transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:bg-[#21386A] dark:bg-white dark:text-[#182B52] dark:hover:bg-[#E6EEFF]"
+                  >
+                    {c.cta.emailLabel}
+                  </a>
+                  <a
+                    href="https://www.linkedin.com/in/oliverpitsch/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-[15px] font-semibold text-[#182B52] transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:border-[#8DAEF0] hover:bg-[#F8FBFF] dark:border-slate-600 dark:bg-transparent dark:text-white dark:hover:border-[#8DAEF0] dark:hover:bg-[#193056]"
+                  >
+                    {c.cta.linkedinLabel}
+                  </a>
+                </div>
+
+                <p className="mt-5 text-center text-[13px] leading-6 text-slate-500 dark:text-slate-400">
+                  {c.cta.legalNote}{' '}
+                  <Link href="/imprint" className="underline underline-offset-4">
+                    {c.cta.legalLinkLabel}
+                  </Link>
+                  .
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <footer className="mt-20 mb-1 text-center relative">
+          <div className="bg-[#FFD500] py-2 text-[12px] flex items-center justify-center gap-4">
+            <Link href="/imprint" className="underline text-[#182B52]">
+              {c.footer.imprintLabel}
+            </Link>
+            <span className="text-[#182B52]/40">|</span>
+            <Link href={c.footer.langSwitchHref} className="underline text-[#182B52]">
+              {c.footer.langSwitchLabel}
+            </Link>
+          </div>
+          <div className="absolute left-0 right-0 -bottom-1 h-1 bg-gradient-to-b from-[#FFBF00] to-[#FFAA00]" />
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/consulting-content.ts
+++ b/src/lib/consulting-content.ts
@@ -1,0 +1,412 @@
+export type ConsultingContent = {
+  lang: string;
+  meta: {
+    title: string;
+    description: string;
+    keywords: string[];
+    ogTitle: string;
+    ogDescription: string;
+  };
+  hero: {
+    badge: string;
+    headline: string;
+    subheadline: string;
+    cta1Label: string;
+    cta1Href: string;
+    cta2Label: string;
+  };
+  painPoints: {
+    heading: string;
+    items: { title: string; description: string }[];
+  };
+  services: {
+    heading: string;
+    items: { title: string; description: string; bullets: string[] }[];
+  };
+  approach: {
+    heading: string;
+    steps: { number: string; title: string; description: string }[];
+  };
+  about: {
+    heading: string;
+    bio: string;
+    credentials: string[];
+    linkLabel: string;
+  };
+  faq: {
+    heading: string;
+    items: { question: string; answer: string }[];
+  };
+  cta: {
+    badge: string;
+    heading: string;
+    body: string;
+    emailLabel: string;
+    emailSubject: string;
+    linkedinLabel: string;
+    legalNote: string;
+    legalLinkLabel: string;
+  };
+  footer: {
+    imprintLabel: string;
+    langSwitchLabel: string;
+    langSwitchHref: string;
+  };
+};
+
+export const en: ConsultingContent = {
+  lang: 'en',
+  meta: {
+    title: 'AI Consulting for Product Teams – Oliver Pitsch',
+    description:
+      'AI consulting for product teams adopting Claude Code, Codex, and AI-native workflows. From regular product development to AI-native product management and development, without sacrificing UX quality.',
+    keywords: [
+      'AI consulting',
+      'Claude Code consulting',
+      'Codex consulting',
+      'AI-native product development',
+      'AI product management',
+      'AI consulting product teams',
+      'UX design systems AI',
+      'agentic coding workflows',
+    ],
+    ogTitle: 'AI Consulting for Product Teams – Oliver Pitsch',
+    ogDescription:
+      'Help your product team adopt Claude Code, Codex, and AI-native workflows. Consulting by Oliver Pitsch.',
+  },
+  hero: {
+    badge: 'AI Consulting',
+    headline: 'Make AI work for your product team',
+    subheadline:
+      'I help companies adopt Claude Code, Codex, and AI-native workflows. Transitioning product management and development teams without sacrificing UX quality or design system coherence.',
+    cta1Label: 'Start a conversation',
+    cta1Href: 'mailto:oliver@pitsch.me?subject=AI%20Consulting%20Inquiry',
+    cta2Label: 'See how I work',
+  },
+  painPoints: {
+    heading: 'Is this you?',
+    items: [
+      {
+        title: 'AI matters, but where to start?',
+        description:
+          'Your team knows AI will change how software gets built, but nobody has a clear plan for what to adopt, where to begin, or how to measure progress.',
+      },
+      {
+        title: 'Claude Code or Codex, but how?',
+        description:
+          'You want to leverage agentic coding tools but need guidance on setup, workflows, prompt engineering, and integrating them into your existing CI/CD pipeline.',
+      },
+      {
+        title: 'PMs and devs need new workflows',
+        description:
+          'Your product managers and developers need to transition from traditional ways of working to AI-native product development, and nobody has done it before in your org.',
+      },
+      {
+        title: 'UX quality must not suffer',
+        description:
+          'You are worried that the rush to adopt AI tools will erode your design system, degrade user experience, and create inconsistency across your product.',
+      },
+    ],
+  },
+  services: {
+    heading: 'What I offer',
+    items: [
+      {
+        title: 'AI-Native Product Development',
+        description:
+          'Adopt agentic coding tools and reshape how your engineering team builds software.',
+        bullets: [
+          'Claude Code & Codex adoption strategy and hands-on setup',
+          'Agentic coding workflows for individual developers and teams',
+          'Prompt engineering and context management for better AI output',
+          'Integration with existing CI/CD, code review, and quality gates',
+        ],
+      },
+      {
+        title: 'AI-Native Product Management',
+        description: 'Redefine the product management role for the age of AI-assisted building.',
+        bullets: [
+          'AI-assisted specification, prioritization, and planning',
+          'Redefining PM workflows: from writing tickets to steering agents',
+          'Product strategy when building speed increases 10x',
+          'Measuring and communicating AI-driven productivity gains',
+        ],
+      },
+      {
+        title: 'UX & Design System Preservation',
+        description:
+          'Maintain design quality and consistency while your team adopts AI-powered tools.',
+        bullets: [
+          'Quality gates for AI-generated UI code',
+          'Integrating design tokens and component libraries into AI workflows',
+          'Ensuring accessibility and brand consistency with agentic output',
+          'Review processes that catch drift before it ships',
+        ],
+      },
+    ],
+  },
+  approach: {
+    heading: 'How we work together',
+    steps: [
+      {
+        number: '01',
+        title: 'Discovery',
+        description:
+          'We assess your current workflows, tech stack, and team dynamics. I identify where AI can create the most leverage and where the risks are.',
+      },
+      {
+        number: '02',
+        title: 'Implementation',
+        description:
+          'Hands-on workshops, tool setup, and workflow redesign. I work alongside your team: pair building sessions, not just slide decks.',
+      },
+      {
+        number: '03',
+        title: 'Enablement',
+        description:
+          'Team training, documentation, and ongoing sparring. Your team becomes self-sufficient. I measure impact and help you communicate results.',
+      },
+    ],
+  },
+  about: {
+    heading: 'Why me',
+    bio: 'I have 20 years of experience across design, UX, and product leadership. I founded an AI SaaS company (Reputami), led product and UX at Trusted Shops, and currently serve as Head of Product at Ordio. I built famili.one, a family organization app, entirely as a solo builder with zero external development, using Claude Code and AI agents end to end. I am not just advising. I am shipping real products with these tools every day.',
+    credentials: [
+      '20 years product & UX',
+      'Head of Product at Ordio',
+      'Solo-built famili.one with AI',
+      'Founded AI SaaS (Reputami)',
+      'Director UX at Trusted Shops',
+    ],
+    linkLabel: 'More about me →',
+  },
+  faq: {
+    heading: 'Frequently asked questions',
+    items: [
+      {
+        question: 'What is AI-native product development?',
+        answer:
+          'AI-native product development means building software with AI agents as core members of the delivery workflow, not as an afterthought. Developers use tools like Claude Code and Codex to write, review, and ship code. Product managers steer agents with context and intent rather than writing detailed specifications. The entire cycle from idea to shipped feature compresses dramatically.',
+      },
+      {
+        question: 'What tools do you specialize in?',
+        answer:
+          'I work primarily with Claude Code and OpenAI Codex. Many teams already use GitHub Copilot, which has grown well beyond code completion into planning, sub-agents, and multi-file edits. If your team is on Copilot, that is a great starting point. I help you get the most out of what you already have and expand into deeper agentic workflows with Claude Code and Codex where it makes sense. The consulting is tool-agnostic at the strategic level: it is about workflows, team structure, and building culture, not just which tool you pick.',
+      },
+      {
+        question: 'How long does a typical engagement take?',
+        answer:
+          'Most engagements start with a 2 to 4 week discovery and initial implementation phase. Ongoing enablement and sparring can continue for 2 to 3 months depending on team size and ambition. I also offer focused one-week intensives for teams that want to move fast.',
+      },
+      {
+        question: 'Do you work with teams that have no AI experience?',
+        answer:
+          'Yes, and in fact that is often where I create the most value. I help teams go from zero to productive with AI tools, building confidence and competence step by step. The key is starting with real work, not toy projects.',
+      },
+      {
+        question: 'How do you ensure UX quality is not sacrificed?',
+        answer:
+          'I bring 20 years of UX and design system experience to every engagement. We set up quality gates, integrate your design tokens into AI workflows, and establish review processes that catch inconsistencies before they reach users. AI speed without UX quality is just faster chaos.',
+      },
+      {
+        question: 'What does it cost?',
+        answer:
+          'Pricing depends on scope, team size, and engagement format. I offer daily rates for workshops and intensives, and project-based pricing for longer engagements. Reach out and we will find a model that fits.',
+      },
+    ],
+  },
+  cta: {
+    badge: 'Get in touch',
+    heading: 'Ready to make AI work for your team?',
+    body: 'Whether you are just getting started with AI tools or want to accelerate an existing adoption, let us talk. I offer a free 30-minute discovery call to understand your situation and see if there is a fit.',
+    emailLabel: 'Email me directly',
+    emailSubject: 'AI%20Consulting%20Inquiry',
+    linkedinLabel: 'Message on LinkedIn',
+    legalNote: 'Prefer formal contact details? See the',
+    legalLinkLabel: 'imprint and contact information',
+  },
+  footer: {
+    imprintLabel: 'Imprint & Data Privacy',
+    langSwitchLabel: 'Auf Deutsch lesen →',
+    langSwitchHref: '/ai-beratung',
+  },
+};
+
+export const de: ConsultingContent = {
+  lang: 'de',
+  meta: {
+    title: 'KI-Beratung für Produktteams – Oliver Pitsch',
+    description:
+      'KI-Beratung für Produktteams, die Claude Code, Codex und AI-native Workflows einführen wollen. Von klassischer Produktentwicklung zu AI-nativer Produktentwicklung und AI-nativem Produktmanagement, ohne Abstriche bei UX-Qualität.',
+    keywords: [
+      'KI Beratung',
+      'KI Beratung Unternehmen',
+      'Claude Code Beratung',
+      'AI-native Produktentwicklung',
+      'KI Produktmanagement',
+      'KI Beratung Produktteams',
+      'KI Transformation Unternehmen',
+      'Codex Beratung',
+    ],
+    ogTitle: 'KI-Beratung für Produktteams – Oliver Pitsch',
+    ogDescription:
+      'Dein Produktteam mit Claude Code, Codex und AI-nativen Workflows stärken. Beratung von Oliver Pitsch.',
+  },
+  hero: {
+    badge: 'KI-Beratung',
+    headline: 'KI für dein Produktteam nutzbar machen',
+    subheadline:
+      'Ich helfe Unternehmen, Claude Code, Codex und AI-native Workflows einzuführen. Damit Produktmanagement und Entwicklung den Sprung schaffen, ohne UX-Qualität oder Design-System-Konsistenz zu verlieren.',
+    cta1Label: 'Gespräch starten',
+    cta1Href: 'mailto:oliver@pitsch.me?subject=KI-Beratung%20Anfrage',
+    cta2Label: 'So arbeite ich',
+  },
+  painPoints: {
+    heading: 'Kommt dir das bekannt vor?',
+    items: [
+      {
+        title: 'KI ist wichtig, aber wo anfangen?',
+        description:
+          'Dein Team weiß, dass KI die Softwareentwicklung verändern wird, aber es fehlt ein klarer Plan, was eingeführt werden soll, wo man beginnt und wie man Fortschritt misst.',
+      },
+      {
+        title: 'Claude Code oder Codex, aber wie?',
+        description:
+          'Du willst Agentic-Coding-Tools nutzen, brauchst aber Unterstützung bei Setup, Workflows, Prompt Engineering und der Integration in deine bestehende CI/CD-Pipeline.',
+      },
+      {
+        title: 'PMs und Devs brauchen neue Workflows',
+        description:
+          'Deine Produktmanager und Entwickler müssen den Übergang von klassischen Arbeitsweisen zu AI-nativer Produktentwicklung schaffen, und niemand in der Organisation hat das bisher gemacht.',
+      },
+      {
+        title: 'UX-Qualität darf nicht leiden',
+        description:
+          'Du befürchtest, dass der Druck zur schnellen KI-Einführung dein Design System aushöhlt, die User Experience verschlechtert und Inkonsistenzen im Produkt erzeugt.',
+      },
+    ],
+  },
+  services: {
+    heading: 'Mein Angebot',
+    items: [
+      {
+        title: 'AI-Native Produktentwicklung',
+        description:
+          'Agentic-Coding-Tools einführen und die Art verändern, wie dein Engineering-Team Software baut.',
+        bullets: [
+          'Claude Code & Codex Adoptionsstrategie und praktisches Setup',
+          'Agentic-Coding-Workflows für einzelne Entwickler und Teams',
+          'Prompt Engineering und Kontextmanagement für besseren AI-Output',
+          'Integration in bestehende CI/CD-, Code-Review- und Quality-Gate-Prozesse',
+        ],
+      },
+      {
+        title: 'AI-Natives Produktmanagement',
+        description:
+          'Die Rolle des Produktmanagements für das Zeitalter des AI-gestützten Bauens neu definieren.',
+        bullets: [
+          'KI-gestützte Spezifikation, Priorisierung und Planung',
+          'PM-Workflows neu denken: von Tickets schreiben zu Agenten steuern',
+          'Produktstrategie, wenn die Build-Geschwindigkeit sich verzehnfacht',
+          'KI-getriebene Produktivitätsgewinne messen und kommunizieren',
+        ],
+      },
+      {
+        title: 'UX & Design-System-Bewahrung',
+        description:
+          'Designqualität und Konsistenz bewahren, während dein Team AI-gestützte Tools einführt.',
+        bullets: [
+          'Quality Gates für KI-generierten UI-Code',
+          'Design Tokens und Component Libraries in AI-Workflows integrieren',
+          'Barrierefreiheit und Markenkonsistenz bei agentic Output sicherstellen',
+          'Review-Prozesse, die Drift erkennen, bevor er live geht',
+        ],
+      },
+    ],
+  },
+  approach: {
+    heading: 'So arbeiten wir zusammen',
+    steps: [
+      {
+        number: '01',
+        title: 'Discovery',
+        description:
+          'Wir analysieren deine aktuellen Workflows, deinen Tech Stack und deine Teamdynamik. Ich identifiziere, wo KI den größten Hebel bietet und wo die Risiken liegen.',
+      },
+      {
+        number: '02',
+        title: 'Implementierung',
+        description:
+          'Praxisnahe Workshops, Tool-Setup und Workflow-Redesign. Ich arbeite mit deinem Team: Pair-Building-Sessions, keine Folienschlachten.',
+      },
+      {
+        number: '03',
+        title: 'Enablement',
+        description:
+          'Teamtraining, Dokumentation und laufendes Sparring. Dein Team wird eigenständig. Ich messe den Impact und helfe dir, die Ergebnisse zu kommunizieren.',
+      },
+    ],
+  },
+  about: {
+    heading: 'Warum ich',
+    bio: 'Ich bringe 20 Jahre Erfahrung in Design, UX und Product Leadership mit. Ich habe ein AI-SaaS-Unternehmen gegründet (Reputami), Produkt und UX bei Trusted Shops geleitet und bin aktuell Head of Product bei Ordio. Ich habe famili.one, eine Familienorganisations-App, komplett als Solo-Builder ohne externe Entwicklung gebaut, durchgehend mit Claude Code und AI-Agenten. Ich berate nicht nur. Ich liefere jeden Tag echte Produkte mit diesen Tools aus.',
+    credentials: [
+      '20 Jahre Produkt & UX',
+      'Head of Product bei Ordio',
+      'famili.one solo mit AI gebaut',
+      'AI-SaaS gegründet (Reputami)',
+      'Director UX bei Trusted Shops',
+    ],
+    linkLabel: 'Mehr über mich →',
+  },
+  faq: {
+    heading: 'Häufig gestellte Fragen',
+    items: [
+      {
+        question: 'Was ist AI-native Produktentwicklung?',
+        answer:
+          'AI-native Produktentwicklung bedeutet, Software mit KI-Agenten als festen Bestandteilen des Delivery-Workflows zu bauen, nicht als nachträgliche Ergänzung. Entwickler nutzen Tools wie Claude Code und Codex zum Schreiben, Reviewen und Ausliefern von Code. Produktmanager steuern Agenten mit Kontext und Intention statt detaillierter Spezifikationen. Der gesamte Zyklus von der Idee zum ausgelieferten Feature komprimiert sich dramatisch.',
+      },
+      {
+        question: 'Mit welchen Tools arbeitest du?',
+        answer:
+          'Ich arbeite hauptsächlich mit Claude Code und OpenAI Codex. Viele Teams nutzen bereits GitHub Copilot, das sich längst über Code-Completion hinaus entwickelt hat: Planning, Sub-Agents und Multi-File-Edits sind mittlerweile Teil des Angebots. Wenn dein Team schon auf Copilot setzt, ist das ein guter Startpunkt. Ich helfe, das Beste aus dem herauszuholen, was bereits da ist, und die Workflows mit Claude Code und Codex zu vertiefen, wo es Sinn ergibt. Die Beratung ist auf strategischer Ebene tool-agnostisch: Es geht um Workflows, Teamstruktur und Baukultur, nicht nur darum, welches Tool man wählt.',
+      },
+      {
+        question: 'Wie lange dauert ein typisches Engagement?',
+        answer:
+          'Die meisten Engagements starten mit einer 2- bis 4-wöchigen Discovery- und Implementierungsphase. Laufendes Enablement und Sparring können je nach Teamgröße und Ambition 2 bis 3 Monate weitergehen. Ich biete auch fokussierte Einwochen-Intensivprogramme für Teams, die schnell vorankommen wollen.',
+      },
+      {
+        question: 'Arbeitest du auch mit Teams ohne KI-Erfahrung?',
+        answer:
+          'Ja, und tatsächlich ist das oft der Bereich, in dem ich den größten Mehrwert schaffe. Ich helfe Teams, von null auf produktiv mit KI-Tools zu kommen, und baue Schritt für Schritt Vertrauen und Kompetenz auf. Der Schlüssel: mit echter Arbeit starten, nicht mit Spielprojekten.',
+      },
+      {
+        question: 'Wie stellst du sicher, dass die UX-Qualität nicht leidet?',
+        answer:
+          'Ich bringe 20 Jahre UX- und Design-System-Erfahrung in jedes Engagement ein. Wir richten Quality Gates ein, integrieren deine Design Tokens in AI-Workflows und etablieren Review-Prozesse, die Inkonsistenzen abfangen, bevor sie bei den Nutzern ankommen. KI-Geschwindigkeit ohne UX-Qualität ist nur schnelleres Chaos.',
+      },
+      {
+        question: 'Was kostet das?',
+        answer:
+          'Die Preise hängen von Umfang, Teamgröße und Engagement-Format ab. Ich biete Tagessätze für Workshops und Intensivprogramme sowie projektbasierte Preise für längere Engagements. Schreib mir und wir finden ein Modell, das passt.',
+      },
+    ],
+  },
+  cta: {
+    badge: 'Kontakt',
+    heading: 'Bereit, KI für dein Team einzusetzen?',
+    body: 'Ob du gerade erst mit KI-Tools startest oder eine bestehende Einführung beschleunigen willst: Lass uns sprechen. Ich biete ein kostenloses 30-minütiges Discovery-Gespräch, um deine Situation zu verstehen und zu sehen, ob es passt.',
+    emailLabel: 'Direkt per E-Mail',
+    emailSubject: 'KI-Beratung%20Anfrage',
+    linkedinLabel: 'Nachricht auf LinkedIn',
+    legalNote: 'Formale Kontaktdaten gewünscht? Siehe',
+    legalLinkLabel: 'Impressum und Kontaktinformationen',
+  },
+  footer: {
+    imprintLabel: 'Impressum & Datenschutz',
+    langSwitchLabel: 'Read in English →',
+    langSwitchHref: '/ai-consulting',
+  },
+};


### PR DESCRIPTION
## Summary
- New landing pages at `/ai-consulting` (English) and `/ai-beratung` (German) for AI consulting services
- Shared `ConsultingPage` component with bilingual content dictionary for easy maintenance
- Full SEO: JSON-LD structured data (ProfessionalService, FAQPage, BreadcrumbList), hreflang cross-linking, OpenGraph/Twitter cards
- Agentic AI discoverability via updated `llms.txt` and sitemap
- Sections: Hero, pain points, services (AI-Native Dev, AI-Native PM, UX preservation), approach, credibility, FAQ, contact CTA
- German version uses informal "Du" tone

## Test plan
- [x] Verify `/ai-consulting` and `/ai-beratung` render correctly in dev server
- [x] Check dark mode on both pages
- [x] Validate JSON-LD at https://validator.schema.org
- [x] Confirm hreflang tags link correctly between EN/DE
- [x] Test all mailto and LinkedIn CTAs
- [x] Verify mobile responsiveness
- [x] Confirm `npm run build` succeeds with static export

🤖 Generated with [Claude Code](https://claude.com/claude-code)